### PR TITLE
Add login flow to Expo chat app

### DIFF
--- a/RandomChatApp/frontend/App.js
+++ b/RandomChatApp/frontend/App.js
@@ -1,25 +1,65 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { StyleSheet, Text, View, TextInput, Button, FlatList } from 'react-native';
 
 export default function App() {
+  const [name, setName] = useState('');
+  const [age, setAge] = useState('');
+  const [connected, setConnected] = useState(false);
   const [messages, setMessages] = useState([]);
   const [input, setInput] = useState('');
-  let socket;
+  const socket = useRef(null);
 
   useEffect(() => {
-    socket = new WebSocket('ws://localhost:3000');
-    socket.onmessage = event => {
-      setMessages(prev => [...prev, event.data]);
-    };
-    return () => socket.close();
-  }, []);
+    if (connected) {
+      socket.current = new WebSocket('ws://localhost:3000');
+      socket.current.onmessage = event => {
+        setMessages(prev => [...prev, event.data]);
+      };
+      return () => socket.current.close();
+    }
+  }, [connected]);
+
+  const connect = () => {
+    if (name.trim() && age.trim()) {
+      setConnected(true);
+    }
+  };
 
   const sendMessage = () => {
-    if (input.trim()) {
-      socket.send(input);
+    if (input.trim() && socket.current) {
+      socket.current.send(`${name}: ${input}`);
       setInput('');
     }
   };
+
+  const newChat = () => {
+    if (socket.current) {
+      socket.current.close();
+    }
+    setMessages([]);
+    setConnected(false);
+  };
+
+  if (!connected) {
+    return (
+      <View style={styles.container}>
+        <TextInput
+          style={styles.input}
+          placeholder="Nombre"
+          value={name}
+          onChangeText={setName}
+        />
+        <TextInput
+          style={styles.input}
+          placeholder="Edad"
+          value={age}
+          keyboardType="numeric"
+          onChangeText={setAge}
+        />
+        <Button title="Conectar" onPress={connect} />
+      </View>
+    );
+  }
 
   return (
     <View style={styles.container}>
@@ -32,9 +72,11 @@ export default function App() {
         style={styles.input}
         onChangeText={setInput}
         value={input}
-        placeholder="Type a message"
+        placeholder="Escribí un mensaje"
       />
-      <Button title="Send" onPress={sendMessage} />
+      <Button title="Enviar" onPress={sendMessage} />
+      <View style={{ height: 10 }} />
+      <Button title="Nuevo chat" onPress={newChat} />
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- extend React Native Expo app so users enter name and age before connecting
- connect to backend via WebSocket and show chat messages
- provide buttons to send and start a new chat

## Testing
- `npm install` in `RandomChatApp/backend`
- `npm test` in `RandomChatApp/backend`


------
https://chatgpt.com/codex/tasks/task_e_6881a1f8c5ec8323af71a1563f9e22c0