### PR TITLE
Add Docker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,15 @@ npm test
 ```
 
 The tests verify that users are paired correctly and that messages are stored in the SQLite database.
+
+## Running with Docker
+
+You can start both the backend and frontend using Docker Compose. From the
+repository root run:
+
+```bash
+docker-compose up --build
+```
+
+The backend will be available on port `3000` and the Expo development server for
+the frontend will be exposed on ports `19000`, `19001`, `19002` and `8081`.

--- a/RandomChatApp/backend/Dockerfile
+++ b/RandomChatApp/backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18
+WORKDIR /app
+COPY package*.json ./
+RUN npm install --production
+COPY . .
+EXPOSE 3000
+CMD ["node", "server.js"]

--- a/RandomChatApp/frontend/Dockerfile
+++ b/RandomChatApp/frontend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 19000 19001 19002 8081
+CMD ["npx", "expo", "start", "--tunnel"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+services:
+  backend:
+    build: ./RandomChatApp/backend
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./RandomChatApp/backend/chat.db:/app/chat.db
+  frontend:
+    build: ./RandomChatApp/frontend
+    ports:
+      - "19000:19000"
+      - "19001:19001"
+      - "19002:19002"
+      - "8081:8081"
+    environment:
+      - EXPO_DEVTOOLS_LISTEN_ADDRESS=0.0.0.0
+    stdin_open: true
+    tty: true


### PR DESCRIPTION
## Summary
- add Dockerfile for backend
- add Dockerfile for frontend
- orchestrate with docker-compose
- document Docker usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881a2b818708323980b190a765b9c1e