### PR TITLE
Fix expo version mismatch and database path

### DIFF
--- a/RandomChatApp/backend/server.js
+++ b/RandomChatApp/backend/server.js
@@ -2,13 +2,20 @@ const express = require('express');
 const http = require('http');
 const WebSocket = require('ws');
 const sqlite3 = require('sqlite3').verbose();
+const fs = require('fs');
+const path = require('path');
 
 const app = express();
 const server = http.createServer(app);
 const wss = new WebSocket.Server({ server });
 
 // SQLite database for storing messages
-const db = new sqlite3.Database('./chat.db');
+const defaultDb = path.join(__dirname, 'chat.db');
+let dbPath = process.env.DB_FILE || defaultDb;
+if (fs.existsSync(dbPath) && fs.lstatSync(dbPath).isDirectory()) {
+  dbPath = path.join(dbPath, 'chat.db');
+}
+const db = new sqlite3.Database(dbPath);
 db.serialize(() => {
   db.run(`CREATE TABLE IF NOT EXISTS messages (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/RandomChatApp/frontend/package.json
+++ b/RandomChatApp/frontend/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "expo": "~48.0.0",
     "react": "18.2.0",
-    "react-native": "0.71.0"
+    "react-native": "0.71.14"
   },
   "scripts": {
     "start": "expo start"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,9 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - ./RandomChatApp/backend/chat.db:/app/chat.db
+      - ./RandomChatApp/backend/db:/db
+    environment:
+      - DB_FILE=/db/chat.db
   frontend:
     build: ./RandomChatApp/frontend
     ports:


### PR DESCRIPTION
## Summary
- use `DB_FILE` environment variable for SQLite path
- mount `db` directory in docker-compose and pass `DB_FILE`
- bump React Native to 0.71.14 for Expo compatibility
- add placeholder file to keep `db` directory in git

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881a685c20883239473e21cfbf25a42